### PR TITLE
chore: set default metadata title to short version

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ const materialSymbols = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Tracker Pathways - Discover the private tracker network",
+  title: "Tracker Pathways",
   description: "Find your way to the trackers worth chasing.",
 };
 


### PR DESCRIPTION
Shortened the default global title to keep things clean.