### PR TITLE
chore: switch docker image source to docker hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   trackerpathways:
-    image: ghcr.io/handokota/trackerpathways:latest
+    image: handokota/trackerpathways:latest
     container_name: trackerpathways
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Updated compose file to pull the image from Docker Hub instead of GHCR.