### PR TITLE
Add shortest paths from My Trackers to a target in graph and search

### DIFF
--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -4,13 +4,17 @@ import { DataStructure, PathResult } from "@/types";
 
 const data = rawData as unknown as DataStructure;
 
+interface RouteSearchResult extends PathResult {
+  stepDays: Array<number | null>;
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const sourceRaw = searchParams.get("source") || "";
   const targetRaw = searchParams.get("target") || "";
-  const maxJumps = parseInt(searchParams.get("jumps") || "1");
+  const maxJumps = Number.parseInt(searchParams.get("jumps") || "1", 10);
   const maxDaysStr = searchParams.get("days");
-  const maxDays = maxDaysStr ? parseInt(maxDaysStr) : null;
+  const maxDays = maxDaysStr ? Number.parseInt(maxDaysStr, 10) : null;
 
   const sQueryRaw = sourceRaw.toLowerCase().trim();
   const sourceInputs = sQueryRaw ? sQueryRaw.split(',').map(s => s.trim()).filter(s => s) : [];
@@ -56,8 +60,8 @@ export async function GET(request: Request) {
   }
 
   const startNodeSet = new Set(startNodes);
-  const results: any[] = [];
-  const queue: any[] = [];
+  const results: RouteSearchResult[] = [];
+  const queue: RouteSearchResult[] = [];
 
   startNodes.forEach(start => {
     queue.push({
@@ -65,6 +69,7 @@ export async function GET(request: Request) {
       target: start,
       nodes: [start],
       totalDays: 0,
+      stepDays: [],
       routes: []
     });
   });
@@ -75,8 +80,11 @@ export async function GET(request: Request) {
   while (queue.length > 0) {
     if (pathsFound >= MAX_PATHS_LIMIT) break;
 
-    const currentPath = queue.shift()!;
+    const currentPath = queue.shift();
+    if (!currentPath) continue;
+
     const currentNode = currentPath.nodes[currentPath.nodes.length - 1];
+    if (!currentNode) continue;
 
     if (currentPath.nodes.length > 1) {
       let isTargetMatch = true;
@@ -110,11 +118,11 @@ export async function GET(request: Request) {
         if (!currentPath.nodes.includes(nextTracker)) {
           const edgeDays = details.days;
           const forumReq = data.unlockInviteClass[currentNode];
-          const forumDays = forumReq ? forumReq[0] : 0;
+          const forumDays = forumReq?.[0] ?? 0;
           let stepDays: number | null = null;
           
           if (edgeDays !== null) {
-            stepDays = Math.max(edgeDays, forumDays || 0);
+            stepDays = Math.max(edgeDays, forumDays);
           }
 
           const nextTotalDays = (currentPath.totalDays === null || stepDays === null) ? null : currentPath.totalDays + stepDays;
@@ -126,6 +134,7 @@ export async function GET(request: Request) {
             target: nextTracker,
             nodes: [...currentPath.nodes, nextTracker],
             totalDays: nextTotalDays,
+            stepDays: [...currentPath.stepDays, stepDays],
             routes: [...currentPath.routes, details]
           });
         }

--- a/src/components/TrackerGraph.tsx
+++ b/src/components/TrackerGraph.tsx
@@ -19,6 +19,14 @@ interface TrackerGraphProps {
   rawData: DataStructure;
 }
 
+interface CollectionPathOption {
+  id: string;
+  source: string;
+  nodes: string[];
+  totalDays: number | null;
+  stepDays: Array<number | null>;
+}
+
 export default function TrackerGraph({ data, rawData }: TrackerGraphProps) {
   const { resolvedTheme } = useTheme();
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
@@ -30,6 +38,9 @@ export default function TrackerGraph({ data, rawData }: TrackerGraphProps) {
   const [pathStart, setPathStart] = useState<string>("");
   const [pathEnd, setPathEnd] = useState<string>("");
   const [activePath, setActivePath] = useState<string[] | null>(null);
+  const [pathSortBy, setPathSortBy] = useState<"jumps" | "days">("jumps");
+  const [useCollectionAsSource, setUseCollectionAsSource] = useState(false);
+  const [selectedCollectionPathId, setSelectedCollectionPathId] = useState<string | null>(null);
 
   const [pathStartInput, setPathStartInput] = useState("");
   const [showPathStartSug, setShowPathStartSug] = useState(false);
@@ -88,6 +99,76 @@ export default function TrackerGraph({ data, rawData }: TrackerGraphProps) {
     return neighbors;
   }, [collectionNodes, data.links, rawData]);
 
+  const getCollectionPathId = (source: string, nodes: string[]) => `${source}>${nodes.join(">")}`;
+
+  const collectionPathOptions = useMemo<CollectionPathOption[]>(() => {
+    if (!useCollectionAsSource || !pathEnd || collectionNodes.length === 0) {
+      return [];
+    }
+
+    const timedPaths: CollectionPathOption[] = [];
+
+    for (const source of collectionNodes) {
+      if (source === pathEnd) {
+        continue;
+      }
+
+      const nodes = findShortestPath(rawData, source, pathEnd);
+      if (!nodes || nodes.length < 2) {
+        continue;
+      }
+
+      let totalDays: number | null = 0;
+      const stepDays: Array<number | null> = [];
+
+      for (let index = 0; index < nodes.length - 1; index += 1) {
+        const fromNode = nodes[index];
+        const toNode = nodes[index + 1];
+        const route = rawData.routeInfo[fromNode]?.[toNode];
+        const routeDays = route?.days;
+        const unlockDays = rawData.unlockInviteClass[fromNode]?.[0] ?? 0;
+
+        if (routeDays === null || routeDays === undefined) {
+          stepDays.push(null);
+          totalDays = null;
+          continue;
+        }
+
+        const stepTime = Math.max(routeDays, unlockDays);
+        stepDays.push(stepTime);
+        if (totalDays !== null) {
+          totalDays += stepTime;
+        }
+      }
+
+      timedPaths.push({
+        id: getCollectionPathId(source, nodes),
+        source,
+        nodes,
+        totalDays,
+        stepDays,
+      });
+    }
+
+    return timedPaths.sort((a, b) => {
+      if (pathSortBy === "days") {
+        if (a.totalDays === null && b.totalDays !== null) return 1;
+        if (a.totalDays !== null && b.totalDays === null) return -1;
+        if (a.totalDays !== null && b.totalDays !== null && a.totalDays !== b.totalDays) {
+          return a.totalDays - b.totalDays;
+        }
+      }
+
+      const hopsA = a.nodes.length - 1;
+      const hopsB = b.nodes.length - 1;
+      if (hopsA !== hopsB) {
+        return hopsA - hopsB;
+      }
+
+      return a.source.localeCompare(b.source);
+    });
+  }, [collectionNodes, pathEnd, pathSortBy, rawData, useCollectionAsSource]);
+
   useEffect(() => {
     const updateDimensions = () => {
       if (containerRef.current) {
@@ -105,14 +186,58 @@ export default function TrackerGraph({ data, rawData }: TrackerGraphProps) {
   }, []);
 
   useEffect(() => {
+    if (useCollectionAsSource) {
+      setPathStart("");
+      setPathStartInput("");
+      setShowPathStartSug(false);
+      setPathStartActiveIndex(-1);
+    }
+  }, [useCollectionAsSource]);
+
+  useEffect(() => {
+    if (!useCollectionAsSource) {
+      return;
+    }
+
+    if (collectionPathOptions.length === 0) {
+      setSelectedCollectionPathId(null);
+      return;
+    }
+
+    if (
+      selectedCollectionPathId
+      && collectionPathOptions.some((path) => path.id === selectedCollectionPathId)
+    ) {
+      return;
+    }
+
+    setSelectedCollectionPathId(collectionPathOptions[0].id);
+  }, [collectionPathOptions, selectedCollectionPathId, useCollectionAsSource]);
+
+  useEffect(() => {
+    if (useCollectionAsSource) {
+      const selectedCollectionPath = collectionPathOptions.find((path) => path.id === selectedCollectionPathId);
+      setActivePath(selectedCollectionPath?.nodes || null);
+      setSelectedNodeId(null);
+      return;
+    }
+
     if (pathStart && pathEnd) {
       const path = findShortestPath(rawData, pathStart, pathEnd);
       setActivePath(path);
       setSelectedNodeId(null);
-    } else {
-      setActivePath(null);
+      return;
     }
-  }, [pathStart, pathEnd, rawData]);
+
+    setActivePath(null);
+  }, [
+    collectionPathOptions,
+    pathEnd,
+    pathStart,
+    rawData,
+    selectedCollectionPathId,
+    useCollectionAsSource,
+  ]);
 
   useEffect(() => {
     if (pathStartActiveIndex >= 0 && pathStartListRef.current) {
@@ -273,6 +398,13 @@ export default function TrackerGraph({ data, rawData }: TrackerGraphProps) {
     }
   };
 
+  const formatStepDays = (days: number | null) => (days === null ? "?" : `${days}d`);
+
+  const selectedCollectionPath = useMemo(
+    () => collectionPathOptions.find((path) => path.id === selectedCollectionPathId) || null,
+    [collectionPathOptions, selectedCollectionPathId]
+  );
+
   const isDark = resolvedTheme === "dark";
   const defaultNodeColor = isDark ? "#60a5fa" : "#2563eb";
   const dimColor = isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.05)";
@@ -309,16 +441,77 @@ export default function TrackerGraph({ data, rawData }: TrackerGraphProps) {
 
           <div className={`transition-all duration-500 ease-in-out ${isPanelOpen ? "max-h-[500px] opacity-100 border-t border-foreground/10 overflow-visible" : "max-h-0 opacity-0 border-t-0 overflow-hidden"}`}>
             <div className="p-4 flex flex-col gap-4 min-w-[250px]">
+              <div className="flex items-center justify-between gap-2">
+                <button
+                  onClick={() => setUseCollectionAsSource((current) => !current)}
+                  disabled={collectionNodes.length === 0}
+                  className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-semibold transition-colors ${
+                    useCollectionAsSource
+                      ? "bg-green-500/15 text-green-600 dark:text-green-300 border border-green-500/40"
+                      : "bg-foreground/5 text-foreground/70 border border-foreground/10"
+                  } ${
+                    collectionNodes.length === 0
+                      ? "cursor-not-allowed opacity-50"
+                      : "hover:bg-foreground/10"
+                  }`}
+                >
+                  <span className="material-symbols-rounded text-sm">bookmarks</span>
+                  Use My Trackers
+                </button>
+
+                {useCollectionAsSource && (
+                  <div className="flex rounded-md bg-foreground/5 p-0.5">
+                    <button
+                      onClick={() => setPathSortBy("jumps")}
+                      className={`px-2 py-1 text-xs rounded-sm transition-colors ${
+                        pathSortBy === "jumps"
+                          ? "bg-foreground/10 text-foreground"
+                          : "text-foreground/60 hover:text-foreground"
+                      }`}
+                    >
+                      Jumps
+                    </button>
+                    <button
+                      onClick={() => setPathSortBy("days")}
+                      className={`px-2 py-1 text-xs rounded-sm transition-colors ${
+                        pathSortBy === "days"
+                          ? "bg-foreground/10 text-foreground"
+                          : "text-foreground/60 hover:text-foreground"
+                      }`}
+                    >
+                      Days
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {useCollectionAsSource && collectionNodes.length === 0 && (
+                <p className="text-xs text-foreground/50 leading-relaxed">
+                  Add trackers in the Collection panel to find routes from your current trackers.
+                </p>
+              )}
               
               <div className="flex flex-col gap-1.5 relative">
                 <label className="text-sm font-medium text-muted-foreground ml-1">Source Tracker</label>
                 <input
                   type="text"
-                  placeholder="Search starting tracker..."
-                  className="w-full bg-foreground/5 border border-foreground/10 rounded-md text-sm p-2.5 outline-none focus:border-green-500/50 transition-colors"
-                  value={pathStartInput}
-                  onFocus={() => setShowPathStartSug(true)}
+                  disabled={useCollectionAsSource}
+                  placeholder={useCollectionAsSource ? "Using My Trackers" : "Search starting tracker..."}
+                  className={`w-full bg-foreground/5 border border-foreground/10 rounded-md text-sm p-2.5 outline-none transition-colors ${
+                    useCollectionAsSource
+                      ? "cursor-not-allowed text-foreground/50"
+                      : "focus:border-green-500/50"
+                  }`}
+                  value={useCollectionAsSource ? collectionNodes.join(", ") : pathStartInput}
+                  onFocus={() => {
+                    if (!useCollectionAsSource) {
+                      setShowPathStartSug(true);
+                    }
+                  }}
                   onChange={(e) => {
+                    if (useCollectionAsSource) {
+                      return;
+                    }
                     setPathStartInput(e.target.value);
                     setPathStart(""); 
                     setShowPathStartSug(true);
@@ -326,8 +519,14 @@ export default function TrackerGraph({ data, rawData }: TrackerGraphProps) {
                   }}
                   onKeyDown={handlePathStartKeyDown}
                 />
+
+                {useCollectionAsSource && (
+                  <span className="text-xs text-foreground/50 ml-1">
+                    Using {collectionNodes.length} tracker{collectionNodes.length === 1 ? "" : "s"} from collection.
+                  </span>
+                )}
                 
-                {showPathStartSug && getSuggestions(pathStartInput).length > 0 && (
+                {!useCollectionAsSource && showPathStartSug && getSuggestions(pathStartInput).length > 0 && (
                   <>
                     <div className="fixed inset-0 z-30" onClick={() => setShowPathStartSug(false)} />
                     <div className="absolute top-full left-0 w-full mt-1 bg-card border border-foreground/10 rounded-xl overflow-hidden z-40 max-h-40 overflow-y-auto p-1" ref={pathStartListRef}>
@@ -388,23 +587,81 @@ export default function TrackerGraph({ data, rawData }: TrackerGraphProps) {
                 )}
               </div>
 
-              {pathStart && pathEnd && !activePath && (
+              {useCollectionAsSource && pathEnd && collectionPathOptions.length === 0 && (
+                <div className="text-sm text-red-500 font-medium text-center py-1">
+                  No path found from My Trackers
+                </div>
+              )}
+              {useCollectionAsSource && pathEnd && selectedCollectionPath && (
+                <div className="text-sm text-green-500 font-medium text-center py-1 flex items-center justify-center gap-1.5">
+                  <span className="material-symbols-rounded text-base">check_circle</span>
+                  Best route: {collectionPathOptions[0].source} ({collectionPathOptions[0].nodes.length - 1} steps)
+                </div>
+              )}
+              {!useCollectionAsSource && pathStart && pathEnd && !activePath && (
                 <div className="text-sm text-red-500 font-medium text-center py-1">
                   No path found
                 </div>
               )}
-              {pathStart && pathEnd && activePath && (
+              {!useCollectionAsSource && pathStart && pathEnd && activePath && (
                 <div className="text-sm text-green-500 font-medium text-center py-1 flex items-center justify-center gap-1.5">
                   <span className="material-symbols-rounded text-base">check_circle</span>
                   Path found ({activePath.length - 1} steps)
                 </div>
               )}
 
-              {(pathStart || pathEnd || pathStartInput || pathEndInput) && (
+              {useCollectionAsSource && pathEnd && collectionPathOptions.length > 0 && (
+                <div className="flex flex-col gap-2 max-h-52 overflow-y-auto pr-1">
+                  {collectionPathOptions.map((pathOption, index) => {
+                    const isSelected = selectedCollectionPathId === pathOption.id;
+
+                    return (
+                      <button
+                        key={pathOption.id}
+                        onClick={() => setSelectedCollectionPathId(pathOption.id)}
+                        className={`rounded-lg border p-2.5 text-left transition-colors ${
+                          isSelected
+                            ? "border-green-500/40 bg-green-500/10"
+                            : "border-foreground/10 bg-foreground/5 hover:bg-foreground/10"
+                        }`}
+                      >
+                        <div className="flex items-center justify-between gap-1 text-xs mb-1">
+                          <span className="font-semibold text-foreground">{pathOption.source}</span>
+                          <span className="text-foreground/60">{pathOption.nodes.length - 1} hops</span>
+                          <span className={pathOption.totalDays === null ? "text-foreground/40" : "text-foreground/70"}>
+                            {pathOption.totalDays === null ? "Unknown" : `${pathOption.totalDays}d`}
+                          </span>
+                        </div>
+                        <div className="text-[11px] text-foreground/50 leading-relaxed">
+                          {pathOption.nodes.slice(0, -1).map((node, stepIndex) => (
+                            <span key={`${pathOption.id}-${node}-${stepIndex}`}>
+                              {stepIndex > 0 && " • "}
+                              {node}
+                              <span className="material-symbols-rounded align-middle text-[11px] mx-0.5">arrow_right_alt</span>
+                              {pathOption.nodes[stepIndex + 1]}
+                              {" ("}
+                              {formatStepDays(pathOption.stepDays[stepIndex] ?? null)}
+                              {")"}
+                            </span>
+                          ))}
+                        </div>
+                        {index === 0 && (
+                          <div className="mt-1 text-[11px] font-medium text-green-600/80 dark:text-green-300/80">
+                            Shortest by {pathSortBy === "days" ? "total time" : "hops"}
+                          </div>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
+              {(pathStart || pathEnd || pathStartInput || pathEndInput || useCollectionAsSource) && (
                 <button
                   onClick={() => { 
                     setPathStart(""); setPathEnd(""); 
                     setPathStartInput(""); setPathEndInput(""); 
+                    setSelectedCollectionPathId(null);
                   }}
                   className="text-sm text-muted-foreground hover:text-foreground underline decoration-dotted mt-1 self-center"
                 >

--- a/src/components/TrackerSearchApp.tsx
+++ b/src/components/TrackerSearchApp.tsx
@@ -17,10 +17,10 @@ export default function TrackerSearchApp() {
   const [viewMode, setViewMode] = useState<'grid' | 'list'>((searchParams.get("view") as 'grid' | 'list') || 'grid');
     
   const [maxJumps, setMaxJumps] = useState<number>(
-    searchParams.get("jumps") ? parseInt(searchParams.get("jumps")!) : 1
+    searchParams.get("jumps") ? Number.parseInt(searchParams.get("jumps")!, 10) : 1
   );
   const [maxDays, setMaxDays] = useState<number | null>(
-    searchParams.get("days") ? parseInt(searchParams.get("days")!) : null
+    searchParams.get("days") ? Number.parseInt(searchParams.get("days")!, 10) : null
   );
   const [sortBy, setSortBy] = useState<'days' | 'jumps'>((searchParams.get("sort") as 'days' | 'jumps') || 'jumps');
 
@@ -46,9 +46,24 @@ export default function TrackerSearchApp() {
 
   const [foundPaths, setFoundPaths] = useState<PathResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [myTrackers, setMyTrackers] = useState<string[]>([]);
 
   useEffect(() => {
     setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    try {
+      const savedCollection = localStorage.getItem("tracker-collection") || "";
+      const trackers = savedCollection
+        .split(",")
+        .map((tracker) => tracker.trim())
+        .filter(Boolean);
+
+      setMyTrackers(trackers);
+    } catch (error) {
+      console.error("Failed to read tracker collection", error);
+    }
   }, []);
 
   useEffect(() => {
@@ -239,6 +254,34 @@ export default function TrackerSearchApp() {
     }
   };
 
+  const useMyTrackersAsSource = () => {
+    if (myTrackers.length === 0) {
+      return;
+    }
+
+    setSourceSearch(myTrackers.join(", "));
+    setShowSourceSug(false);
+    setSourceActiveIndex(-1);
+  };
+
+  const getPathId = (path: PathResult) => `${path.source}>${path.nodes.join(">")}`;
+
+  const getStepDays = (path: PathResult, routeIndex: number) => {
+    const stepDayFromApi = path.stepDays?.[routeIndex];
+    if (stepDayFromApi !== undefined) {
+      return stepDayFromApi;
+    }
+
+    const route = path.routes[routeIndex];
+    if (!route || route.days === null) {
+      return null;
+    }
+
+    const sourceNode = path.nodes[routeIndex];
+    const unlockDays = data.unlockInviteClass[sourceNode]?.[0] ?? 0;
+    return Math.max(route.days, unlockDays);
+  };
+
   const getStatusColor = (status: string) => {
     const s = status.toLowerCase();
     if (s === 'yes' || s === 'open') return 'text-green-700 dark:text-green-300 bg-green-100 dark:bg-green-900/30';
@@ -277,10 +320,11 @@ export default function TrackerSearchApp() {
   const sortedPaths = useMemo(() => {
     return [...foundPaths].sort((a, b) => {
       if (sortBy === 'days') {
-        if (a.totalDays === null && b.totalDays !== null) return 1;
-        if (a.totalDays !== null && b.totalDays === null) return -1;
-        if (a.totalDays === null && b.totalDays === null) return 0;
-        return a.totalDays - b.totalDays;
+        const aTotalDays = a.totalDays ?? Number.POSITIVE_INFINITY;
+        const bTotalDays = b.totalDays ?? Number.POSITIVE_INFINITY;
+        if (aTotalDays !== bTotalDays) {
+          return aTotalDays - bTotalDays;
+        }
       }
         
       if (a.routes.length !== b.routes.length) {
@@ -290,6 +334,8 @@ export default function TrackerSearchApp() {
       return a.target.localeCompare(b.target);
     });
   }, [foundPaths, sortBy]);
+
+  const bestPathId = sortedPaths.length > 0 ? getPathId(sortedPaths[0]) : null;
 
   const groupedResults = useMemo(() => {
     const groups: { [key: string]: PathResult[] } = {};
@@ -365,6 +411,19 @@ export default function TrackerSearchApp() {
                     </div>
                   </div>
                 )}
+                <div className="mt-1 flex justify-end">
+                  <button
+                    onClick={useMyTrackersAsSource}
+                    disabled={myTrackers.length === 0}
+                    className={`text-xs font-medium px-2 py-1 rounded-md transition-colors ${
+                      myTrackers.length === 0
+                        ? "text-foreground/30 bg-foreground/5 cursor-not-allowed"
+                        : "text-foreground/70 bg-foreground/5 hover:bg-foreground/10"
+                    }`}
+                  >
+                    {myTrackers.length === 0 ? "No My Trackers saved" : `Use My Trackers (${myTrackers.length})`}
+                  </button>
+                </div>
               </div>
 
               <div className="h-px w-full bg-foreground/5 my-1"></div>
@@ -578,12 +637,21 @@ export default function TrackerSearchApp() {
                       ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
                       : "grid grid-cols-1 gap-3"
                   }>
-                    {paths.map((path, idx) => {
+                    {paths.map((path) => {
                       const targetAbbr = getAbbr(path.target);
                       const isDirect = path.routes.length === 1;
+                      const pathId = getPathId(path);
+                      const isBestPath = pathId === bestPathId;
 
                       return (
-                        <div key={idx} className="group flex flex-col p-5 rounded-xl bg-card border border-foreground/10 transition-colors duration-200 h-full">
+                        <div
+                          key={pathId}
+                          className={`group flex flex-col p-5 rounded-xl border transition-colors duration-200 h-full ${
+                            isBestPath
+                              ? "border-green-500/40 bg-green-500/5"
+                              : "bg-card border-foreground/10"
+                          }`}
+                        >
                           
                           <div className="flex justify-between items-start mb-3 gap-4"> 
                             <div className="min-w-0">
@@ -592,6 +660,12 @@ export default function TrackerSearchApp() {
                                 <div className="font-bold text-foreground text-lg wrap-break-word">{path.target}</div>
                                 
                                 <div className="flex items-center gap-2 shrink-0">
+                                  {isBestPath && (
+                                    <span className="flex items-center gap-1.5 text-xs font-semibold text-green-700 dark:text-green-300 bg-green-100 dark:bg-green-900/30 px-2 py-0.5 rounded-md">
+                                      <span className="material-symbols-rounded text-sm">workspace_premium</span>
+                                      Best path
+                                    </span>
+                                  )}
                                   <span className={badgeClass}>
                                     {targetAbbr}
                                   </span>
@@ -619,6 +693,7 @@ export default function TrackerSearchApp() {
                             {path.routes.map((req, rIdx) => {
                               const fromNode = path.nodes[rIdx];
                               const toNode = path.nodes[rIdx + 1];
+                              const stepDays = getStepDays(path, rIdx);
                               
                               return (
                                 <div key={rIdx} className="text-sm pl-3 relative border-l-2 border-foreground/10">
@@ -627,6 +702,9 @@ export default function TrackerSearchApp() {
                                       <span>{fromNode}</span><span className="material-symbols-rounded text-base">arrow_right_alt</span><span>{toNode}</span>
                                     </div>
                                   )}
+                                  <div className={`text-xs font-medium mb-1 ${stepDays === null ? "text-foreground/40" : "text-foreground/60"}`}>
+                                    Step time: {stepDays === null ? "Unknown" : `${stepDays} days`}
+                                  </div>
                                   <p className="text-foreground/70 leading-relaxed font-normal text-sm">{renderReqs(req.reqs)}</p>
                                   
                                   <div className="flex flex-col gap-2 mt-3 pt-3 border-t border-foreground/5 border-dashed">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,12 @@
 export interface RouteDetail {
-  days: number;
+  days: number | null;
   reqs: string;
   active: string;
   updated: string;
 }
 
 export type UnlockClass = [
-  number,
+  number | null,
   string
 ];
 
@@ -28,7 +28,8 @@ export interface PathResult {
   source: string;
   target: string;
   nodes: string[];
-  totalDays: number;
+  totalDays: number | null;
+  stepDays?: Array<number | null>;
   routes: RouteDetail[];
 }
 


### PR DESCRIPTION
## Summary
- add My Trackers route options in the map pathfinder to find routes from collection trackers to a selected target
- default-highlight the shortest route and add sorting between jumps and total time in the map pathfinder
- add a search-page action to auto-fill source trackers from the saved collection and highlight the best result
- include per-step time details in search results and API responses

## Validation
- npm run build
- docker build -t trackerpathways:issue-86 .

Closes #86