### PR TITLE
fix(data): remove seedpool from HD-Space invite paths

### DIFF
--- a/src/data/trackers.json
+++ b/src/data/trackers.json
@@ -561,8 +561,7 @@
       "ZmPT": { "days": 0, "reqs": "PU+", "active": "Yes", "updated": "Aug 2025" }
     },
     "HD-Space": {
-      "DigitalCore.Club": { "days": 0, "reqs": "No requirement", "active": "Yes", "updated": "Nov 2025" },
-      "seedpool": { "days": 30, "reqs": "HD Spacer, 1 month", "active": "Yes", "updated": "Nov 2025" }
+      "DigitalCore.Club": { "days": 0, "reqs": "No requirement", "active": "Yes", "updated": "Nov 2025" }
     },
     "HD-Torrents": {
       "DigitalCore.Club": { "days": 0, "reqs": "Profile will be reviewed", "active": "Yes", "updated": "Nov 2025" },


### PR DESCRIPTION
## Summary

- HD-Space no longer offers invites to seedpool, so the entry has been removed from the tracker data.

## Proof

![HD-Space seedpool removed](https://i.ibb.co/xt83YD13/image.png)