### PR TITLE
fix(data): remove DigitalCore.Club from HD-Space invite paths

### DIFF
--- a/src/data/trackers.json
+++ b/src/data/trackers.json
@@ -561,7 +561,6 @@
       "ZmPT": { "days": 0, "reqs": "PU+", "active": "Yes", "updated": "Aug 2025" }
     },
     "HD-Space": {
-      "DigitalCore.Club": { "days": 0, "reqs": "No requirement", "active": "Yes", "updated": "Nov 2025" },
       "seedpool": { "days": 30, "reqs": "HD Spacer, 1 month", "active": "Yes", "updated": "Nov 2025" }
     },
     "HD-Torrents": {


### PR DESCRIPTION
## Summary

- DigitalCore.Club no longer offers invites through HD-Space, so the entry has been removed.

## Proof

![DigitalCore.Club removed from HD-Space](https://i.ibb.co/kVp3Rc2g/image.png)